### PR TITLE
Add FailFastParallelCheck

### DIFF
--- a/gtg/good_to_go.go
+++ b/gtg/good_to_go.go
@@ -72,7 +72,7 @@ func FailFastParallelCheck(checkers []StatusChecker) StatusChecker {
 				statusChannel <- status
 			}()
 		}
-		for idx := 0; idx < len(checkers); idx++ {
+		for range checkers {
 			select {
 			case status := <-statusChannel:
 				if status.GoodToGo == false {

--- a/gtg/good_to_go_test.go
+++ b/gtg/good_to_go_test.go
@@ -51,6 +51,30 @@ func TestTimeoutRunningManyStatusChecksThatAlwaysPass(t *testing.T) {
 	assert.EqualValues(timeoutMessage, status.Message)
 }
 
+func TestFailFastParallelCheckFailure(t *testing.T) {
+	assert := assert.New(t)
+	statusCheck := FailFastParallelCheck([]StatusChecker{delayedChecker(localNoError, 1), delayedChecker(localNoError, 1), delayedChecker(localNoError, 1), delayedChecker(localNoError, 1), delayedChecker(localError, 2)})
+	status := statusCheck.RunCheck()
+	assert.False(status.GoodToGo)
+	assert.EqualValues(localErrorMessage, status.Message)
+}
+
+func TestFailFastParallelCheckSuccess(t *testing.T) {
+	assert := assert.New(t)
+	statusCheck := FailFastParallelCheck([]StatusChecker{delayedChecker(localNoError, 2), delayedChecker(localNoError, 2), delayedChecker(localNoError, 2), delayedChecker(localNoError, 2), delayedChecker(localNoError, 2)})
+	status := statusCheck.RunCheck()
+	assert.True(status.GoodToGo)
+	assert.EqualValues("OK", status.Message)
+}
+
+func TestFailFastParallelCheckTimeout(t *testing.T) {
+	assert := assert.New(t)
+	statusCheck := FailAtEndSequentialChecker([]StatusChecker{delayedChecker(localNoError, 1), delayedChecker(localNoError, 1), delayedChecker(localNoError, 1), delayedChecker(localNoError, 1), delayedChecker(localNoError, 5)})
+	status := statusCheck.RunCheck()
+	assert.False(status.GoodToGo)
+	assert.EqualValues(timeoutMessage, status.Message)
+}
+
 var localErrorMessage = "There is a problem with the wibble setting, please adjust your set"
 
 func localError() (status Status) {


### PR DESCRIPTION
Allows a composite to checkers to be run simultaneously, as soon as the first checker fails the results of any other checks are ignored.
